### PR TITLE
Allow APL to work with the module classes

### DIFF
--- a/manifests/child_domain_controller.pp
+++ b/manifests/child_domain_controller.pp
@@ -27,7 +27,7 @@
 class active_directory::child_domain_controller (
   String[1]                      $domain_name,
   String[1]                      $domain_credential_user,
-  Sensitive[String[1]]           $domain_credential_passwd,
+  String[1]                      $domain_credential_passwd,
 
   # Use hiera for defaults
   Stdlib::AbsolutePath           $ad_db_path,
@@ -47,7 +47,7 @@ class active_directory::child_domain_controller (
 
   $_domain_credentials = {
     'user'     => $domain_credential_user,
-    'password' => $domain_credential_passwd,
+    'password' => Sensitive($domain_credential_passwd),
   }
 
   dsc_xwaitforaddomain { $domain_name:

--- a/manifests/domain_controller.pp
+++ b/manifests/domain_controller.pp
@@ -29,10 +29,10 @@
 # }
 #
 class active_directory::domain_controller (
-  Sensitive[String[1]] $domain_credential_passwd,
-  String               $domain_credential_user,
-  String               $domain_name,
-  Sensitive[String[1]] $safe_mode_passwd,
+  String[1] $domain_credential_passwd,
+  String[1] $domain_credential_user,
+  String[1] $domain_name,
+  String[1] $safe_mode_passwd,
 
   # Uses hiera for defaults
   Optional[Hash]       $ad_users,
@@ -53,12 +53,12 @@ class active_directory::domain_controller (
 
   $_domain_credentials = {
     'user'     => $domain_credential_user,
-    'password' => $domain_credential_passwd,
+    'password' => Sensitive($domain_credential_passwd),
   }
 
   $_safemode_credentials = {
     'user'     => 'Administrator',
-    'password' => $safe_mode_passwd,
+    'password' => Sensitive($safe_mode_passwd),
   }
 
   if $parent_domain_name {

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/dsc",

--- a/spec/classes/child_domain_controller_spec.rb
+++ b/spec/classes/child_domain_controller_spec.rb
@@ -10,7 +10,7 @@ describe 'active_directory::child_domain_controller' do
     let :params do
       {
         domain_credential_user:    'Admininstrator',
-        domain_credential_passwd:  RSpec::Puppet::RawString.new("Sensitive('vftybeisudvfkyj rtysaerfvacjtyDMZHfvfgty')"),
+        domain_credential_passwd:  'vftybeisudvfkyj rtysaerfvacjtyDMZHfvfgty',
         domain_name:               'puppet.local',
       }
     end

--- a/spec/classes/domain_controller_spec.rb
+++ b/spec/classes/domain_controller_spec.rb
@@ -9,8 +9,8 @@ describe 'active_directory::domain_controller' do
     let :params do
       {
         domain_credential_user:    'Admininstrator',
-        domain_credential_passwd:  RSpec::Puppet::RawString.new("Sensitive('vftybeisudvfkyj rtysaerfvacjtyDMZHfvfgty')"),
-        safe_mode_passwd:          RSpec::Puppet::RawString.new("Sensitive('EvenW0rse%')"),
+        domain_credential_passwd:  'vftybeisudvfkyj rtysaerfvacjtyDMZHfvfgty',
+        safe_mode_passwd:          'EvenW0rse%',
         domain_name:               'puppet.local',
       }
     end


### PR DESCRIPTION
* Removed the `Sensitive` data type from the class paramters since this
  interferes with APL
* Wrapped the appropriate variables in `Sensitive()` to ensure that they
  were passed to the underlying types safely
* Bumped up the supported version of `stdlib`

Closes #5